### PR TITLE
更新「绿坝」文章的部分链接

### DIFF
--- a/docs/censorship/绿坝.md
+++ b/docs/censorship/绿坝.md
@@ -26,4 +26,4 @@ dateCreated: "2022-09-27T21:40:14"
 > +   《[绿坝娘](https://zh.wikipedia.org/zh-cn/绿坝娘)》, 维基百科.
 > +   《[绿坝娘](https://web.archive.org/web/20220728024453/https://zh.moegirl.org.cn/绿坝娘)》, 萌娘百科.
 > +   《[和谐你全家](https://web.archive.org/web/20220904040245/https://zh.moegirl.org.cn/和谐你全家)》, 萌娘百科.
-> +   《[Bilibili/绿坝娘争议和影响](https://web.archive.org/web/20221129030108/https://zh.moegirl.org.cn/Bilibili/%E4%BA%89%E8%AE%AE%E5%92%8C%E5%BD%B1%E5%93%8D#%E7%BB%BF%E5%9D%9D%E5%A8%98)》, 萌娘百科.
+> +   《[Bilibili/绿坝娘争议和影响](https://web.archive.org/web/20221129030108/https://zh.moegirl.org.cn/Bilibili/争议和影响#绿坝娘)》, 萌娘百科.

--- a/docs/censorship/绿坝.md
+++ b/docs/censorship/绿坝.md
@@ -26,4 +26,4 @@ dateCreated: "2022-09-27T21:40:14"
 > +   《[绿坝娘](https://zh.wikipedia.org/zh-cn/绿坝娘)》, 维基百科.
 > +   《[绿坝娘](https://web.archive.org/web/20220728024453/https://zh.moegirl.org.cn/绿坝娘)》, 萌娘百科.
 > +   《[和谐你全家](https://web.archive.org/web/20220904040245/https://zh.moegirl.org.cn/和谐你全家)》, 萌娘百科.
-> +   《[Bilibili/绿坝娘争议和影响](https://zh.moegirl.org.cn/Bilibili/争议和影响#绿坝娘)》, 萌娘百科.
+> +   《[Bilibili/绿坝娘争议和影响](https://web.archive.org/web/20221129030108/https://zh.moegirl.org.cn/Bilibili/%E4%BA%89%E8%AE%AE%E5%92%8C%E5%BD%B1%E5%93%8D#%E7%BB%BF%E5%9D%9D%E5%A8%98)》, 萌娘百科.


### PR DESCRIPTION
由于该页面已经 404，需要更新成「互联网档案馆」的链接。