### PR TITLE
将 facebook 链接替换成 archive 后的链接，修复部分失效的 facebook 链接

### DIFF
--- a/docs/game/Blue_Archive.md
+++ b/docs/game/Blue_Archive.md
@@ -38,7 +38,7 @@ dateCreated: "2022-11-14T21:57:06"
 
 2021年12月15日 左右，玩家国际版更新的第二章内容与日版不同，爱丽丝的全身像被裁剪成了头像，导致了玩家的反感，导致 Google Play 的评分曾经被刷到 1.9 的低分（满分是 5 分），随后游戏官方发布了公告，表示这是不得不调整的情况，未来会尽量避免这种情况。[^EtHbl][^58242][^38898][^rg4dsp]
 
-[^EtHbl]: 蔚藍檔案, 《[開發者的信 #1](https://www.facebook.com/TW.BlueArchive/posts/pfbid0pWkL2gXHRrRQRsyoYArTooxNj1BTCAceUDsdkvsv1tFRpGC7GEc5sYRBZJfEEtHbl)》, 2021-12-15. (参照 2022-11-14).
+[^EtHbl]: 蔚藍檔案, 《[開發者的信 #1](http://web.archive.org/web/20230810161237/https://www.facebook.com/TW.BlueArchive/posts/136565035438305/)》, 2021-12-15. (参照 2022-11-14).
 
 [^58242]: BlueArchive, 《[Here is a letter from PD Kim Yong-ha regarding the revision of the Aris scenario production.](https://web.archive.org/web/20220811170434/https://twitter.com/EN_BlueArchive/status/1471366983534858242)》, Twitter, 2021-12-16. (参照 2022-11-14).
 

--- a/docs/game/以闪亮之名.md
+++ b/docs/game/以闪亮之名.md
@@ -27,7 +27,7 @@ dateCreated: "2023-07-27T15:05:00"
 
 2023年7月27日，《以闪亮之名》的台服运营商始祖鸟娱乐发布了停运公告：[^GZYYl]
 
-[^GZYYl]: 以閃亮之名, 《[以閃亮之名港澳台版本終止運營公告](https://www.facebook.com/LifeMakeoverTW/posts/pfbid02wzTJVPhyvHvdw7Lg4SXsJWVZT3KVqUgBbrkH3pahXf1H91JxLvqHvW8G1mEMGZYYl)》, facebook, 2023-07-27. (参照 2023-07-27).
+[^GZYYl]: 以閃亮之名, 《[以閃亮之名港澳台版本終止運營公告](https://web.archive.org/web/20230810160822/https://www.facebook.com/LifeMakeoverTW/posts/pfbid02wzTJVPhyvHvdw7Lg4SXsJWVZT3KVqUgBbrkH3pahXf1H91JxLvqHvW8G1mEMGZYYl)》, facebook, 2023-07-27. (参照 2023-07-27).
 
 > [!quote]+ 以閃亮之名港澳台版本終止運營公告
 >

--- a/docs/sound/我们的海阔天空.md
+++ b/docs/sound/我们的海阔天空.md
@@ -36,7 +36,7 @@ dateCreated: "2021-08-08T23:07:02"
 
 [^aobws]: [黃明志新歌微博禁播！　內地歌手秒速割席拒合唱 - 香港01](https://web.archive.org/web/20210722072737if_/https://www.hk01.com/眾樂迷/464162/黃明志新歌微博禁播-內地歌手秒速割席拒合唱)
 
-[^fb_nwe]: [Namewee 黃明志 - 這首歌已經在微博被禁了。富九的經紀公司也寫了聲明稿. - facebook](https://www.facebook.com/namewee/posts/10157800100393429)
+[^fb_nwe]: [Namewee 黃明志 - 這首歌已經在微博被禁了。富九的經紀公司也寫了聲明稿. - facebook](https://web.archive.org/web/20230810160534/https://www.facebook.com/namewee/posts/10157800100393429)
 
 ### 相关链接
 

--- a/docs/website/Wordpress.md
+++ b/docs/website/Wordpress.md
@@ -11,20 +11,20 @@ dateCreated: "2021-08-09T09:49:34"
 
 ## 关闭网站
 
-> HKLC [2021年6月2日](https://www.facebook.com/HKLiberationCoalition/photos/a.120537356852613/123329963240019/)
+> HKLC [2021年6月2日](http://web.archive.org/web/20230810155557/https://www.facebook.com/HKLiberationCoalition/photos/a.120537356852613/123329963240019/)
 >
 > 我哋個網站俾人強行落咗架，原因不明。<br>
 > 我們將尋求其他方案，並暫時在社交媒體發佈我們的最新訊息。
 
 ---
 
-> HKLC [2021年6月2日](https://www.facebook.com/HKLiberationCoalition/photos/a.120697460169936/123512289888453/)
+> HKLC [2021年6月2日](http://web.archive.org/web/20230810160341/https://www.facebook.com/HKLiberationCoalition/photos/a.120697460169936/123512289888453/)
 >
 > 我們啟用不足兩星期的網站 hk liberation.com被 Wordpress 強行下架，現在正和Wordpress 交涉中。
 
 ---
 
-> HKLC [2021年6月5日](https://www.facebook.com/HKLiberationCoalition/posts/124289936477355)
+> HKLC [2021年6月5日](http://web.archive.org/web/20230810160309/https://www.facebook.com/HKLiberationCoalition/posts/124289936477355)
 >
 > [https://hongkongfp.com/…/pro-democrat-exile-group-claims-p…/](https://archive.is/qKa2a "https://hongkongfp.com/2021/06/05/pro-democrat-exile-group-claims-pressure-from-hong-kong-police-forced-wordpress-to-censor-website/")
 >


### PR DESCRIPTION
现在 Facebook 无需登入就可以正常 archive，将这些链接替换成 archive 后的链接以防失效。

「蔚蓝档案 開發者的信 `#1` 」这个原始链接我打开后一直是白页面无法加载出内容，我找到了可用链接。

